### PR TITLE
Adding missing defined variables for hi-hat

### DIFF
--- a/Programs/keymaps/default/keymap.sfz
+++ b/Programs/keymaps/default/keymap.sfz
@@ -25,6 +25,7 @@
 #define $HH_CLOSED_KEY 42
 #define $HH_PEDAL_KEY 44
 #define $HH_OPEN_KEY 46
+//Also see more hi-hat settings at the bottom of the file
 
 //General MIDI percussion keys
 
@@ -72,11 +73,17 @@
 #define $SNARE_ROLL_KEY 96
 
 //For e-drum use, set the half and 34 keys to 46 also, and use the CC ranges below
-#define $HH_HALF_KEY 90 //Octave above the GM hat keys, normally cowbell etc.
+#define $HH_HALF_KEY 90 //Default octave above the GM hat keys, normally cowbell etc.
 #define $HH_SPLASH_KEY 92
 #define $HH_34_KEY 94
 
 //For e-drum use, set the ranges for the hi-hat pedal here
+//If closed is on its own key, usually 42, this would be 0 to 127
+//And the three below would be split across the 0 to 127 range
+//If closed is also on MIDI note 46, split the 0 to 127 range in four
+#define $HH_CLOSED_LOCC 0
+#define $HH_CLOSED_HICC 127
+
 #define $HH_HALF_LOCC 0
 #define $HH_HALF_HICC 127
 
@@ -87,3 +94,14 @@
 #define $HH_OPEN_HICC 127
 
 #define $HH_MUTE_TIME 0.7
+
+//Hi-hat pedal offsets
+//The higher this is, the more responsive the hi-hat pedal sound will feel
+//but there will be less realistic pedal noise before the cymbals clash
+//
+//Set this to 0 and 1200 to restore the behavior of the old versions
+//2000 and 2200 would probably be the maximum that's possible
+//The second value is for the epic mics
+//It should be half of 2400 minus the first value
+#define $HH_PPREROLL 1000 //Was effectively 0 up to version 0.925
+#define $HH_EPPREROLL 1700 //Was 1200 up to version 0.925

--- a/Programs/keymaps/default/keymap_basic.sfz
+++ b/Programs/keymaps/default/keymap_basic.sfz
@@ -58,3 +58,11 @@
 #define $PERC_BELLTREE_KEY 84
 
 #define $HH_MUTE_TIME 0.7
+
+//Hi-hat pedal offset
+//The higher this is, the more responsive the hi-hat pedal sound will feel
+//but there will be less realistic pedal noise before the cymbals clash
+//
+//Set this to 0 to restore the behavior of the old versions
+//2200 would probably be the maximum that's possible
+#define $HH_PPREROLL 1000 //Was effectively 0 up to version 0.925

--- a/Programs/keymaps/hihat_on_pedal/keymap.sfz
+++ b/Programs/keymaps/hihat_on_pedal/keymap.sfz
@@ -22,9 +22,11 @@
 #define $FLATRIDE_RIDE_KEY 59
 #define $FLATRIDE_CRASH_KEY 55 //GM splash cymbal key
 
+//Closed is on one key, open, 3/4 and half on another
 #define $HH_CLOSED_KEY 42
 #define $HH_PEDAL_KEY 44
 #define $HH_OPEN_KEY 46
+//Also see more hi-hat settings at the bottom of the file
 
 //General MIDI percussion keys
 
@@ -72,11 +74,17 @@
 #define $SNARE_ROLL_KEY 96
 
 //For e-drum use, set the half and 34 keys to 46 also, and use the CC ranges below
-#define $HH_HALF_KEY 46 //Octave above the GM hat keys, normally cowbell etc.
+#define $HH_HALF_KEY 46 //Default was octave above the GM hat keys, normally cowbell etc.
 #define $HH_SPLASH_KEY 92
 #define $HH_34_KEY 46
 
 //For e-drum use, set the ranges for the hi-hat pedal here
+//If closed is on its own key, usually 42, and the rest 46, this would be 0 to 127
+//And the three below would be split across the 0 to 127 range
+//If everything from closed to open on MIDI note 42, split the 0 to 127 range in four
+#define $HH_CLOSED_LOCC 0
+#define $HH_CLOSED_HICC 127
+
 #define $HH_HALF_LOCC 0
 #define $HH_HALF_HICC 42
 
@@ -87,3 +95,14 @@
 #define $HH_OPEN_HICC 127
 
 #define $HH_MUTE_TIME 0.7
+
+//Hi-hat pedal offsets
+//The higher this is, the more responsive the hi-hat pedal sound will feel
+//but there will be less realistic pedal noise before the cymbals clash
+//
+//Set this to 0 and 1200 to restore the behavior of the old versions
+//2000 and 2200 would probably be the maximum that's possible
+//The second value is for the epic mics
+//It should be half of 2400 minus the first value
+#define $HH_PPREROLL 1000 //Was effectively 0 up to version 0.925
+#define $HH_EPPREROLL 1700 //Was 1200 up to version 0.925

--- a/Programs/keymaps/hihat_on_pedal/keymap_basic.sfz
+++ b/Programs/keymaps/hihat_on_pedal/keymap_basic.sfz
@@ -58,3 +58,11 @@
 #define $PERC_BELLTREE_KEY 84
 
 #define $HH_MUTE_TIME 0.7
+
+//Hi-hat pedal offset
+//The higher this is, the more responsive the hi-hat pedal sound will feel
+//but there will be less realistic pedal noise before the cymbals clash
+//
+//Set this to 0 to restore the behavior of the old versions
+//2200 would probably be the maximum that's possible
+#define $HH_PPREROLL 1000 //Was effectively 0 up to version 0.925

--- a/Programs/keymaps/keymap.sfz
+++ b/Programs/keymaps/keymap.sfz
@@ -24,7 +24,8 @@
 
 #define $HH_CLOSED_KEY 42
 #define $HH_PEDAL_KEY 44
-#define $HH_OPEN_KEY 46
+#define $HH_OPEN_KEY 42
+//Also see more hi-hat settings at the bottom of the file
 
 //General MIDI percussion keys
 
@@ -71,19 +72,36 @@
 #define $SNARE_FLAM_KEY 95
 #define $SNARE_ROLL_KEY 96
 
-//For e-drum use, set the half and 34 keys to 46 also, and use the CC ranges below
-#define $HH_HALF_KEY 90 //Octave above the GM hat keys, normally cowbell etc.
+//For e-drum use, set the half and 34 keys to 42 also, and use the CC ranges below
+#define $HH_HALF_KEY 42 //Default was octave above the GM hat keys, normally cowbell etc.
 #define $HH_SPLASH_KEY 92
-#define $HH_34_KEY 94
+#define $HH_34_KEY 42
 
 //For e-drum use, set the ranges for the hi-hat pedal here
-#define $HH_HALF_LOCC 0
-#define $HH_HALF_HICC 127
+//If closed is on its own key, usually 42, this would be 0 to 127
+//And the three below would be split across the 0 to 127 range
+//If closed is also on MIDI note 42, split the 0 to 127 range in four
+#define $HH_CLOSED_LOCC 96
+#define $HH_CLOSED_HICC 127
 
-#define $HH_34_LOCC 0
-#define $HH_34_HICC 127
+#define $HH_HALF_LOCC 64
+#define $HH_HALF_HICC 95
+
+#define $HH_34_LOCC 32
+#define $HH_34_HICC 63
 
 #define $HH_OPEN_LOCC 0
-#define $HH_OPEN_HICC 127
+#define $HH_OPEN_HICC 31
 
-#define $HH_MUTE_TIME 0.3
+#define $HH_MUTE_TIME 0.7
+
+//Hi-hat pedal offsets
+//The higher this is, the more responsive the hi-hat pedal sound will feel
+//but there will be less realistic pedal noise before the cymbals clash
+//
+//Set this to 0 and 1200 to restore the behavior of the old versions
+//2000 and 2200 would probably be the maximum that's possible
+//The second value is for the epic mics
+//It should be half of 2400 minus the first value
+#define $HH_PPREROLL 1000 //Was effectively 0 up to version 0.925
+#define $HH_EPPREROLL 1700 //Was 1200 up to version 0.925

--- a/Programs/keymaps/keymap_basic.sfz
+++ b/Programs/keymaps/keymap_basic.sfz
@@ -57,4 +57,12 @@
 #define $PERC_JINGLEBELL_KEY 83
 #define $PERC_BELLTREE_KEY 84
 
-#define $HH_MUTE_TIME 0.3
+#define $HH_MUTE_TIME 0.7
+
+//Hi-hat pedal offset
+//The higher this is, the more responsive the hi-hat pedal sound will feel
+//but there will be less realistic pedal noise before the cymbals clash
+//
+//Set this to 0 to restore the behavior of the old versions
+//2200 would probably be the maximum that's possible
+#define $HH_PPREROLL 1000 //Was effectively 0 up to version 0.925

--- a/Programs/keymaps/perc_down/keymap.sfz
+++ b/Programs/keymaps/perc_down/keymap.sfz
@@ -77,6 +77,12 @@
 #define $HH_34_KEY 58
 
 //For e-drum use, set the ranges for the hi-hat pedal here
+//If closed is on its own key, usually 42, and the rest 46, this would be 0 to 127
+//And the three below would be split across the 0 to 127 range
+//If everything from closed to open on MIDI note 42, split the 0 to 127 range in four
+#define $HH_CLOSED_LOCC 0
+#define $HH_CLOSED_HICC 127
+
 #define $HH_HALF_LOCC 0
 #define $HH_HALF_HICC 127
 
@@ -87,3 +93,14 @@
 #define $HH_OPEN_HICC 127
 
 #define $HH_MUTE_TIME 0.7
+
+//Hi-hat pedal offsets
+//The higher this is, the more responsive the hi-hat pedal sound will feel
+//but there will be less realistic pedal noise before the cymbals clash
+//
+//Set this to 0 and 1200 to restore the behavior of the old versions
+//2000 and 2200 would probably be the maximum that's possible
+//The second value is for the epic mics
+//It should be half of 2400 minus the first value
+#define $HH_PPREROLL 1000 //Was effectively 0 up to version 0.925
+#define $HH_EPPREROLL 1700 //Was 1200 up to version 0.925

--- a/Programs/keymaps/perc_down/keymap_basic.sfz
+++ b/Programs/keymaps/perc_down/keymap_basic.sfz
@@ -58,3 +58,11 @@
 #define $PERC_BELLTREE_KEY 6
 
 #define $HH_MUTE_TIME 0.7
+
+//Hi-hat pedal offset
+//The higher this is, the more responsive the hi-hat pedal sound will feel
+//but there will be less realistic pedal noise before the cymbals clash
+//
+//Set this to 0 to restore the behavior of the old versions
+//2200 would probably be the maximum that's possible
+#define $HH_PPREROLL 1000 //Was effectively 0 up to version 0.925


### PR DESCRIPTION
Replacing the keymaps to add the hi-hat closed key CC configuration (for e-kit players) and also hi-hat pedal preroll variable definitions, because the recently updated keymaps use them, and, well, that breaks the instrument if the old maps are used.