### PR TITLE
Fixing the broken hi-hat pedal

### DIFF
--- a/Programs/mappings/kickmic/hh_silences_basic_map.sfz
+++ b/Programs/mappings/kickmic/hh_silences_basic_map.sfz
@@ -3,8 +3,8 @@
 //Everything except open
 //Just like the splash mute group, except the splash key is in this too
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=44
 off_by=43
 <region>
@@ -17,8 +17,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just splash and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=41
 off_by=40
 <region>

--- a/Programs/mappings/kickmic/hh_silences_map.sfz
+++ b/Programs/mappings/kickmic/hh_silences_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=46
 off_by=46
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=44
 off_by=43
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -52,8 +56,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=43
 off_by=42
 <region>
@@ -62,6 +66,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -70,12 +76,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=42
 off_by=41
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -84,8 +92,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=41
 off_by=40
 <region>

--- a/Programs/mappings/kickmic_all.sfz
+++ b/Programs/mappings/kickmic_all.sfz
@@ -186,7 +186,7 @@ amp_veltrack=100
 amp_velcurve_1=0.4
 //Bleed control
 locc102=85
-//note_polyphony=MAX
+note_polyphony=0
 
 
 <group>
@@ -202,7 +202,7 @@ key=$HH_PEDAL_KEY
 amp_veltrack=50
 group=41
 off_by=40
-ampeg_attack=0.001
+//ampeg_attack=0.001
 offset=$HH_PPREROLL
 #include "mappings/kickmic/hh_pedal_map.sfz"
 
@@ -238,7 +238,7 @@ off_by=43
 #include "mappings/kickmic/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/kickmic/hh_silences_map.sfz"
 
 <master>

--- a/Programs/mappings/kickmic_basic.sfz
+++ b/Programs/mappings/kickmic_basic.sfz
@@ -46,7 +46,7 @@ amp_veltrack=100
 amp_velcurve_1=0.4
 //Bleed control
 locc102=85
-//note_polyphony=MAX
+note_polyphony=0
 
 <group>
 key=$HH_CLOSED_KEY
@@ -59,7 +59,7 @@ key=$HH_PEDAL_KEY
 amp_veltrack=50
 group=41
 off_by=40
-ampeg_attack=0.001
+//ampeg_attack=0.001
 offset=$HH_PPREROLL
 #include "mappings/kickmic/hh_pedal_map.sfz"
 
@@ -72,7 +72,7 @@ off_by=44
 
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/kickmic/hh_silences_basic_map.sfz"
 
 <master>

--- a/Programs/mappings/lofi/hh_silences_epic_map.sfz
+++ b/Programs/mappings/lofi/hh_silences_epic_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=206
 off_by=206
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=204
 off_by=203
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -52,8 +56,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=203
 off_by=202
 <region>
@@ -62,6 +66,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -69,12 +75,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=202
 off_by=201
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -82,8 +90,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=201
 off_by=200
 <region>

--- a/Programs/mappings/lofi/hh_silences_map.sfz
+++ b/Programs/mappings/lofi/hh_silences_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=126
 off_by=126
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=124
 off_by=123
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -52,8 +56,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=123
 off_by=122
 <region>
@@ -62,6 +66,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -70,12 +76,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=122
 off_by=121
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -84,8 +92,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=121
 off_by=120
 <region>

--- a/Programs/mappings/lofi_all.sfz
+++ b/Programs/mappings/lofi_all.sfz
@@ -173,7 +173,7 @@ tune_curvecc76=1
 ampeg_release=$HH_MUTE_TIME
 amp_veltrack=100
 amp_velcurve_1=0.4
-//note_polyphony=MAX
+note_polyphony=0
 
 
 <group>
@@ -190,7 +190,7 @@ amp_veltrack=50
 group=121
 off_by=120
 //Preroll
-ampeg_attack=0.001
+//ampeg_attack=0.001
 offset=$HH_PPREROLL
 #include "mappings/lofi/hh_pedal_map.sfz"
 
@@ -226,7 +226,7 @@ off_by=123
 #include "mappings/lofi/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/lofi/hh_silences_map.sfz"
 
 <master>

--- a/Programs/mappings/lofi_epic_all.sfz
+++ b/Programs/mappings/lofi_epic_all.sfz
@@ -173,7 +173,7 @@ tune_curvecc76=1
 ampeg_release=$HH_MUTE_TIME
 amp_veltrack=100
 amp_velcurve_1=0.4
-//note_polyphony=MAX
+note_polyphony=0
 
 
 <group>
@@ -227,7 +227,7 @@ off_by=203
 #include "mappings/lofi/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/lofi/hh_silences_epic_map.sfz"
 
 <master>

--- a/Programs/mappings/mid/hh_silences_epic_map.sfz
+++ b/Programs/mappings/mid/hh_silences_epic_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=186
 off_by=186
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=184
 off_by=183
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -52,8 +56,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=183
 off_by=182
 <region>
@@ -62,6 +66,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -69,12 +75,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=182
 off_by=181
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -82,8 +90,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=181
 off_by=180
 <region>

--- a/Programs/mappings/mid/hh_silences_map.sfz
+++ b/Programs/mappings/mid/hh_silences_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=106
 off_by=106
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=104
 off_by=103
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -53,8 +57,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=103
 off_by=102
 <region>
@@ -63,6 +67,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -71,12 +77,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=102
 off_by=101
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -85,8 +93,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=101
 off_by=100
 <region>

--- a/Programs/mappings/mid_all.sfz
+++ b/Programs/mappings/mid_all.sfz
@@ -172,7 +172,7 @@ tune_curvecc76=1
 ampeg_release=$HH_MUTE_TIME
 amp_veltrack=100
 amp_velcurve_1=0.4
-//note_polyphony=MAX
+note_polyphony=0
 
 <group>
 key=$HH_CLOSED_KEY
@@ -187,7 +187,7 @@ key=$HH_PEDAL_KEY
 amp_veltrack=50
 group=101
 off_by=100
-ampeg_attack=0.001
+//ampeg_attack=0.001
 offset=$HH_PPREROLL
 #include "mappings/mid/hh_pedal_map.sfz"
 
@@ -223,7 +223,7 @@ off_by=103
 #include "mappings/mid/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/mid/hh_silences_map.sfz"
 
 <master>

--- a/Programs/mappings/mid_epic_all.sfz
+++ b/Programs/mappings/mid_epic_all.sfz
@@ -173,7 +173,7 @@ tune_curvecc76=1
 ampeg_release=$HH_MUTE_TIME
 amp_veltrack=100
 amp_velcurve_1=0.4
-//note_polyphony=MAX
+note_polyphony=0
 
 
 <group>
@@ -227,7 +227,7 @@ off_by=183
 #include "mappings/mid/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/mid/hh_silences_epic_map.sfz"
 
 <master>

--- a/Programs/mappings/oh/hh_silences_basic_map.sfz
+++ b/Programs/mappings/oh/hh_silences_basic_map.sfz
@@ -3,8 +3,8 @@
 //Everything except open
 //Just like the splash mute group, except the splash key is in this too
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=24
 off_by=23
 <region>
@@ -17,8 +17,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just splash and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=21
 <region>
 key=$HH_PEDAL_KEY

--- a/Programs/mappings/oh/hh_silences_epic_map.sfz
+++ b/Programs/mappings/oh/hh_silences_epic_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=146
 off_by=146
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=144
 off_by=143
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -52,8 +56,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=143
 off_by=142
 <region>
@@ -62,6 +66,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -69,12 +75,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=142
 off_by=141
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -82,8 +90,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=141
 off_by=140
 <region>

--- a/Programs/mappings/oh/hh_silences_map.sfz
+++ b/Programs/mappings/oh/hh_silences_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=26
 off_by=26
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=24
 off_by=23
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -52,8 +56,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=23
 off_by=22
 <region>
@@ -62,6 +66,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -69,12 +75,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=22
 off_by=21
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -82,8 +90,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=21
 off_by=20
 <region>

--- a/Programs/mappings/oh_all.sfz
+++ b/Programs/mappings/oh_all.sfz
@@ -172,7 +172,7 @@ tune_curvecc76=1
 ampeg_release=$HH_MUTE_TIME
 amp_veltrack=100
 amp_velcurve_1=0.4
-//note_polyphony=MAX
+note_polyphony=0
 
 <group>
 key=$HH_CLOSED_KEY
@@ -187,7 +187,7 @@ key=$HH_PEDAL_KEY
 amp_veltrack=50
 group=21
 off_by=20
-ampeg_attack=0.001
+//ampeg_attack=0.001
 offset=$HH_PPREROLL
 #include "mappings/oh/hh_pedal_map.sfz"
 
@@ -223,7 +223,7 @@ off_by=23
 #include "mappings/oh/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/oh/hh_silences_map.sfz"
 
 <master>

--- a/Programs/mappings/oh_basic.sfz
+++ b/Programs/mappings/oh_basic.sfz
@@ -43,7 +43,7 @@ key=$SNARE_RIMSHOT_KEY
 ampeg_release=$HH_MUTE_TIME
 amp_veltrack=100
 amp_velcurve_1=0.4
-//note_polyphony=MAX
+note_polyphony=0
 
 
 
@@ -57,7 +57,7 @@ off_by=21
 key=$HH_PEDAL_KEY
 amp_veltrack=50
 group=21
-ampeg_attack=0.001
+//ampeg_attack=0.001
 offset=$HH_PPREROLL
 #include "mappings/oh/hh_pedal_map.sfz"
 
@@ -70,7 +70,7 @@ off_by=24
 
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/oh/hh_silences_basic_map.sfz"
 
 <master>

--- a/Programs/mappings/oh_epic_all.sfz
+++ b/Programs/mappings/oh_epic_all.sfz
@@ -173,7 +173,7 @@ tune_curvecc76=1
 ampeg_release=$HH_MUTE_TIME
 amp_veltrack=100
 amp_velcurve_1=0.4
-//note_polyphony=MAX
+note_polyphony=0
 
 
 <group>
@@ -227,7 +227,7 @@ off_by=143
 #include "mappings/oh/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/oh/hh_silences_epic_map.sfz"
 
 <master>

--- a/Programs/mappings/room/hh_silences_epic_map.sfz
+++ b/Programs/mappings/room/hh_silences_epic_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=166
 off_by=166
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=164
 off_by=163
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -52,8 +56,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=163
 off_by=162
 <region>
@@ -62,6 +66,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -69,12 +75,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=162
 off_by=161
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -82,8 +90,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=161
 off_by=160
 <region>

--- a/Programs/mappings/room/hh_silences_map.sfz
+++ b/Programs/mappings/room/hh_silences_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=86
 off_by=86
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=84
 off_by=83
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -52,8 +56,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=83
 off_by=82
 <region>
@@ -62,6 +66,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -69,12 +75,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=82
 off_by=81
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -82,8 +90,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=81
 off_by=80
 <region>

--- a/Programs/mappings/room_all.sfz
+++ b/Programs/mappings/room_all.sfz
@@ -173,7 +173,7 @@ tune_curvecc76=1
 ampeg_release=$HH_MUTE_TIME
 amp_veltrack=100
 amp_velcurve_1=0.4
-//note_polyphony=MAX
+note_polyphony=0
 
 <group>
 key=$HH_CLOSED_KEY
@@ -188,7 +188,7 @@ key=$HH_PEDAL_KEY
 amp_veltrack=50
 group=81
 off_by=80
-ampeg_attack=0.001
+//ampeg_attack=0.001
 offset=$HH_PPREROLL
 #include "mappings/room/hh_pedal_map.sfz"
 
@@ -224,7 +224,7 @@ off_by=83
 #include "mappings/room/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/room/hh_silences_map.sfz"
 
 <master>

--- a/Programs/mappings/room_epic_all.sfz
+++ b/Programs/mappings/room_epic_all.sfz
@@ -173,7 +173,7 @@ tune_curvecc76=1
 ampeg_release=$HH_MUTE_TIME
 amp_veltrack=100
 amp_velcurve_1=0.4
-//note_polyphony=MAX
+note_polyphony=0
 
 
 <group>
@@ -227,7 +227,7 @@ off_by=163
 #include "mappings/room/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/room/hh_silences_epic_map.sfz"
 
 <master>

--- a/Programs/mappings/snaremic/hh_silences_basic_map.sfz
+++ b/Programs/mappings/snaremic/hh_silences_basic_map.sfz
@@ -3,8 +3,8 @@
 //Everything except open
 //Just like the splash mute group, except the splash key is in this too
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=64
 off_by=63
 <region>
@@ -17,8 +17,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just splash and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=61
 off_by=60
 <region>

--- a/Programs/mappings/snaremic/hh_silences_map.sfz
+++ b/Programs/mappings/snaremic/hh_silences_map.sfz
@@ -6,8 +6,8 @@
 //Kind of a kludge, but keeps the silence from instantly muting the splash
 //while allowing a subsequent splash to mute the current splash
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=66
 off_by=66
 <region>
@@ -20,6 +20,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -31,8 +33,8 @@ key=$HH_PEDAL_KEY
 //Muting a louder hat hit with a quiet one tends to expose the fact that it's a simple fadeout
 //And there should be some edge clash noise as the hat is being closed
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=64
 off_by=63
 <region>
@@ -45,6 +47,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -52,8 +56,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes 3/4 open hi-hats
 //Everything except open and 3/4 and splas
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=63
 off_by=62
 <region>
@@ -62,6 +66,8 @@ locc4=$HH_HALF_LOCC
 hicc4=$HH_HALF_HICC
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -69,12 +75,14 @@ key=$HH_PEDAL_KEY
 //The range which mutes half open hi-hats
 //Just closed and pedal
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=62
 off_by=61
 <region>
 key=$HH_CLOSED_KEY
+locc4=$HH_CLOSED_LOCC
+hicc4=$HH_CLOSED_HICC
 <region>
 key=$HH_PEDAL_KEY
 
@@ -82,8 +90,8 @@ key=$HH_PEDAL_KEY
 //The range which mutes closed hi-hats
 //Just pedal, though with the short duration this could probably be skipped with no real harm
 sample=*silence
-loop_mode=loop_continuous off_mode=fast
-ampeg_attack=0 ampeg_decay=0 ampeg_sustain=0 ampeg_release=0
+off_mode=fast
+end=-1
 group=61
 off_by=60
 <region>

--- a/Programs/mappings/snaremic_all.sfz
+++ b/Programs/mappings/snaremic_all.sfz
@@ -177,7 +177,7 @@ amp_veltrack=100
 amp_velcurve_1=0.4
 //Bleed control
 locc104=85
-//note_polyphony=MAX
+note_polyphony=0
 
 <group>
 key=$HH_CLOSED_KEY
@@ -192,7 +192,7 @@ key=$HH_PEDAL_KEY
 amp_veltrack=50
 group=61
 off_by=60
-ampeg_attack=0.001
+//ampeg_attack=0.001
 offset=$HH_PPREROLL
 #include "mappings/snaremic/hh_pedal_map.sfz"
 
@@ -228,7 +228,7 @@ off_by=63
 #include "mappings/snaremic/hh_34_map.sfz"
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/snaremic/hh_silences_map.sfz"
 
 <master>

--- a/Programs/mappings/snaremic_basic.sfz
+++ b/Programs/mappings/snaremic_basic.sfz
@@ -47,7 +47,7 @@ amp_veltrack=100
 amp_velcurve_1=0.4
 //Bleed control
 locc104=85
-//note_polyphony=MAX
+note_polyphony=0
 
 <group>
 key=$HH_CLOSED_KEY
@@ -60,7 +60,7 @@ key=$HH_PEDAL_KEY
 amp_veltrack=50
 group=61
 off_by=60
-ampeg_attack=0.001
+//ampeg_attack=0.001
 offset=$HH_PPREROLL
 #include "mappings/snaremic/hh_pedal_map.sfz"
 
@@ -73,7 +73,7 @@ off_by=64
 
 
 <master>
-//note_polyphony=MAX
+note_polyphony=0
 #include "mappings/snaremic/hh_silences_basic_map.sfz"
 
 <master>


### PR DESCRIPTION
Putting note_polyphony=0 on the hi-hat groups, replacing the incorrect note_polyphony=MAX Commenting out the ampeg_attack on the hi-hat pedal, as it seems unnecessary for declicking when the offset is used, and causes problems with voice stealing Also making the hi-hat silence groups implemented more cleanly by using end=-1 and removing the zero-length envelopes